### PR TITLE
Remove hero section from homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,17 +3,6 @@ import Layout from '../layouts/Layout.astro';
 ---
 
 <Layout title="Welcome">
-	<section class="hero">
-		<img
-			class="hero-logo"
-			src="https://impressdesigns.dev/static-assets/logos/logo-primary.png"
-			alt="Impress Designs primary logo"
-			width="320"
-		/>
-		<h1>Impress Designs developer docs</h1>
-		<p>Get started integrating with Impress Designs.</p>
-	</section>
-
 	<section class="links">
 		<article>
 			<h2>Product data</h2>
@@ -39,21 +28,10 @@ import Layout from '../layouts/Layout.astro';
 </Layout>
 
 <style>
-	.hero {
-		text-align: center;
-		padding: 2rem 0 1rem;
-	}
-
-	.hero-logo {
-		max-width: 100%;
-		height: auto;
-	}
-
 	.links {
 		display: grid;
 		grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr));
 		gap: 1.25rem;
-		margin-top: 2rem;
 	}
 
 	.links article {


### PR DESCRIPTION
## Summary
Removed the hero section from the homepage, simplifying the landing page layout to focus on the links section.

## Changes
- Removed the hero section markup including the Impress Designs logo, heading, and introductory text
- Deleted associated hero section styles (`.hero` and `.hero-logo` CSS classes)
- Removed the top margin from the links section that was previously spacing it below the hero

## Details
The hero section containing the logo image, "Impress Designs developer docs" heading, and introductory paragraph has been completely removed from the page. The corresponding CSS styling has also been cleaned up, eliminating unused classes and adjusting the links section layout accordingly.

https://claude.ai/code/session_019zPtczXNUtQo2JnV3PAWrV